### PR TITLE
[TS-125] Caching Cypress in CI/CD

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -10,10 +10,10 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    
     strategy:
       matrix:
-        node-version: [ 14.x]
+        node-version: [ 12.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -28,6 +28,8 @@ jobs:
       uses: cypress-io/github-action@v2
       with:
         build: npm run build
-        start: npm run serve
+        start: npm run start-ci
+        wait-on: 'http://localhost:8081'
+        wait-on-timeout: 300
       env: 
         {'CI':''}


### PR DESCRIPTION
Closes [TS-125](https://tradeshare490.atlassian.net/browse/TS-125?atlOrigin=eyJpIjoiYmUzM2RmNDY4MGM2NDNkYzgwZmQ1YzE4NGUwOTFjNzEiLCJwIjoiaiJ9).

Used Cypress from github-action instead of calling it on our own in the pipeline to enable caching Cypress installation. 

Saved 10s-20s compared to the normal runs. 

![image](https://user-images.githubusercontent.com/60043570/136938620-b1615bb7-1ff0-4932-ac23-5c77282ab407.png)



![image](https://user-images.githubusercontent.com/60043570/136938525-1f81ec97-2bd2-479d-a08c-0259fb2c34a9.png)


reference: https://docs.cypress.io/guides/continuous-integration/github-actions#Caching-Dependencies-and-Build-Artifacts  