### PR TITLE
[TS-181] renamed the backend host [HOT FIX]

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
-VUE_APP_BACKEND_HOST=https://ancient-waters-32375.herokuapp.com/api/v1
+VUE_APP_BACKEND_HOST=https://tradeshare-backend-for-dev.herokuapp.com/api/v1
+#VUE_APP_BACKEND_HOST=https://tradeshare-backend-for-test.herokuapp.com/api/v1

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -62,8 +62,5 @@ jobs:
           parallel: true
         env:
           CYPRESS_RECORD_KEY: "ca3f404b-1d73-4ff2-8b09-8a931fb57358"
-          VUE_APP_BACKEND_HOST: "https://ancient-waters-32375.herokuapp.com/api/v1"
+          VUE_APP_BACKEND_HOST: "https://tradeshare-backend-for-test.herokuapp.com/api/v1"
           CI: ""
-
-      - name: Show coverage report
-        run: npm run show-e2e-report

--- a/cypress/fixtures/url.json
+++ b/cypress/fixtures/url.json
@@ -1,6 +1,6 @@
 {
 	"HOMEPAGE": "http://localhost",
-	"HOSTED_BACKEND_URL": "https://ancient-waters-32375.herokuapp.com/api/check",
+	"HOSTED_BACKEND_URL": "https://tradeshare-backend-for-test.herokuapp.com/api/check",
 	"OTHER_DASHBOARD": "/other-dashboard",
 	"FEED": "/news-feed",
 	"DASHBOARD": "/dashboard",


### PR DESCRIPTION
1. Separate the backend host for test and development from `ttps://ancient-waters-32375.herokuapp.com` to `https://tradeshare-backend-for-test.herokuapp.com/api/v1` and `https://tradeshare-backend-for-dev.herokuapp.com/api/v1`

2. Removed `showing`report`. Since tests are run in parallel, a report cannot be complete at the end to be shown