### PR TITLE
[TS-196] Made Messaging Page Dynamic

### DIFF
--- a/cypress/fixtures/url.json
+++ b/cypress/fixtures/url.json
@@ -8,7 +8,7 @@
 	"DASHBOARD": "/dashboard",
 	"FOLLOWERS": "/followers",
 	"FOLLOWING": "/following",
-	"MESSAGES": "/messages",
+	"MESSAGES": "/messages/0",
 	"PREFERENCES": "/preferences",
 	"ICONS_AND_IMAGES": "/icons-and-images",
 	"SUPPORT": "/support",

--- a/cypress/integration/E2E_tests/MessagingTests/messaging.spec.js
+++ b/cypress/integration/E2E_tests/MessagingTests/messaging.spec.js
@@ -8,24 +8,36 @@ describe("On the messaging page, can", () => {
       );
     });
   });
-  it("select a conversation", ()=> {
+  it("select a conversation", () => {
     cy.get("[data-cy=no-messages-window]").should("be.visible");
-    cy.get("[data-cy=chat]").first().click()
+    cy.get("[data-cy=chat]")
+      .first()
+      .click();
     cy.get("[data-cy=messages-window]").should("be.visible");
-  })
+  });
   it("search for people", () => {
-    cy.get("[data-cy=search]").click().type("Jane Doe");
+    cy.get("[data-cy=search]")
+      .click()
+      .type("Jane Doe");
   });
   it("create new chat", () => {
     cy.get("[data-cy=new-message]").click();
   });
-  it("can press the emoji button",()=>{
-    cy.get("[data-cy=chat]").first().click()
-    cy.get("[data-cy=image-button]").should("be.visible").click();
-  })
+  it("can press the emoji button", () => {
+    cy.get("[data-cy=chat]")
+      .first()
+      .click();
+    cy.get("[data-cy=image-button]")
+      .should("be.visible")
+      .click();
+  });
   it("send a message", () => {
-    cy.get("[data-cy=chat]").first().click()
-    cy.get("[data-cy=send-message]").click().type("Hello");
+    cy.get("[data-cy=chat]")
+      .first()
+      .click();
+    cy.get("[data-cy=send-message]")
+      .click()
+      .type("Hello");
     cy.get("[data-cy=send-button]").click();
     cy.get("[data-cy=messages-window]").should("include.text", "Hello");
   });

--- a/cypress/integration/E2E_tests/MessagingTests/messaging.spec.js
+++ b/cypress/integration/E2E_tests/MessagingTests/messaging.spec.js
@@ -1,4 +1,4 @@
-describe("On the messages page, can", () => {
+describe("On the messaging page, can", () => {
   before(() => {
     cy.login();
     cy.wait(2000);
@@ -8,12 +8,10 @@ describe("On the messages page, can", () => {
       );
     });
   });
-  it("display no messages at first", () => {
-    cy.get("[data-cy=no-messages-window]").should("be.visible");
-  });
   it("select a conversation", ()=> {
-    cy.get("[data-cy=chat]").click()
-    cy.get("[data-cu=messages-window]").should("be.visible");
+    cy.get("[data-cy=no-messages-window]").should("be.visible");
+    cy.get("[data-cy=chat]").first().click()
+    cy.get("[data-cy=messages-window]").should("be.visible");
   })
   it("search for people", () => {
     cy.get("[data-cy=search]").click().type("Jane Doe");
@@ -22,9 +20,11 @@ describe("On the messages page, can", () => {
     cy.get("[data-cy=new-message]").click();
   });
   it("can press the emoji button",()=>{
+    cy.get("[data-cy=chat]").first().click()
     cy.get("[data-cy=image-button]").should("be.visible").click();
   })
   it("send a message", () => {
+    cy.get("[data-cy=chat]").first().click()
     cy.get("[data-cy=send-message]").click().type("Hello");
     cy.get("[data-cy=send-button]").click();
     cy.get("[data-cy=messages-window]").should("include.text", "Hello");

--- a/cypress/integration/E2E_tests/MessagingTests/messaging.spec.js
+++ b/cypress/integration/E2E_tests/MessagingTests/messaging.spec.js
@@ -8,9 +8,13 @@ describe("On the messages page, can", () => {
       );
     });
   });
-  it("display messages", () => {
-    cy.get("[data-cy=messages-window]").should("be.visible");
+  it("display no messages at first", () => {
+    cy.get("[data-cy=no-messages-window]").should("be.visible");
   });
+  it("select a conversation", ()=> {
+    cy.get("[data-cy=chat]").click()
+    cy.get("[data-cu=messages-window]").should("be.visible");
+  })
   it("search for people", () => {
     cy.get("[data-cy=search]").click().type("Jane Doe");
   });
@@ -25,9 +29,4 @@ describe("On the messages page, can", () => {
     cy.get("[data-cy=send-button]").click();
     cy.get("[data-cy=messages-window]").should("include.text", "Hello");
   });
-  it("hide messages", () => {
-    cy.get("[data-cy=chat]").click().click();
-    cy.get("[data-cy=messages-window]").should("not.exist");
-  })
-
 });

--- a/src/components/Messages/ChatMenu.vue
+++ b/src/components/Messages/ChatMenu.vue
@@ -1,0 +1,216 @@
+<template>
+  <v-container class="px-0">
+    <v-row style="overflow: hidden">
+      <v-col cols="12" align-self="center" class="py-0 pt-5">
+        <p class="primary--text font-weight-medium">Messages</p>
+        <v-divider />
+      </v-col>
+
+      <v-col cols="12" align-self="center" class="py-0 pt-5">
+        <v-autocomplete
+          dense
+          class="mx-4 text-body-2"
+          flat
+          hide-no-data
+          hide-details
+          label="Search for people and messages"
+          outlined
+          color="primary"
+          hide-selected
+          single
+          line
+          return-object
+          single-line
+          append-icon="mdi-magnify"
+          data-cy="search"
+        ></v-autocomplete>
+      </v-col>
+      <v-col cols="12" align-self="center" class="px-8 pb-6">
+        <v-btn small color="primary" width="100%" data-cy="new-message">
+          <v-icon left>
+            mdi-pencil
+          </v-icon>
+          New Message
+        </v-btn>
+      </v-col>
+    </v-row>
+    <v-divider />
+    <v-responsive class="overflow-y-auto fill-height" height="65vh">
+      <v-list subheader>
+        <v-list-item
+          v-for="user in chats"
+          v-bind:key="user.name"
+          :to="/messages/ + user.id"
+          data-cy="chat"
+          class="px-0"
+          @click="conversationSelected(user.name, user.username, user.img, user.messages)"
+        >
+          <v-list-item :key="`user${index}`" :value="user.id">
+            <v-avatar class="profile" size="40">
+              <v-img :src="user.img"></v-img>
+            </v-avatar>
+            <v-list-item-content class="text-left pl-5">
+              <v-col class="px-0 py-0" cols="6">
+                <v-list-item-title
+                  v-text="user.name"
+                  class="text-wrap text-body-2"
+                />
+              </v-col>
+              <v-col class="px-0 py-0" cols="6">
+                <v-list-item-subtitle
+                  v-text="user.timeLastMessage"
+                  class="text-wrap text-right text-caption"
+                />
+              </v-col>
+              <v-col class="px-0 py-0">
+                <v-list-item-subtitle
+                  v-text="user.lastMessage"
+                  class="pt-2 text-caption text-truncate"
+                  style="max-width: 19vw;"
+                />
+              </v-col>
+            </v-list-item-content>
+          </v-list-item>
+        </v-list-item>
+      </v-list>
+    </v-responsive>
+  </v-container>
+</template>
+
+<script>
+  export default {
+    created() {},
+    methods: {
+      conversationSelected(name, username, img, messages) {
+        this.$emit("clicked", name, username, img, messages);
+      },
+    },
+    computed: {
+      chats() {
+        return [
+          {
+            id: 1,
+            name: "John Doe",
+            username: "@johndoe",
+            img: "https://randomuser.me/api/portraits/men/52.jpg",
+            lastMessage: "What are you up to today?",
+            timeLastMessage: "5m",
+            messages: [
+              {
+                content: "Hey! How have you been",
+                me: true,
+              },
+              {
+                content: "Yoooo, I've been good, you?",
+                me: false,
+              },
+              {
+                content: "I've been sooo busy lately",
+                me: false,
+              },
+              {
+                content: "I'm good, tired as per usual",
+                me: true,
+              },
+              {
+                content: "What's kept you busy?",
+                me: true,
+              },
+              {
+                content:
+                  "This new project I took on, man is it time consuming. I thought it was going to be a lot easier...",
+                me: false,
+              },
+              {
+                content: "Rip, I hope it's fun at least",
+                me: true,
+              },
+              {
+                content: "Rip, I hope it's fun at least",
+                me: true,
+              },
+              {
+                content: "Rip, I hope it's fun at least",
+                me: true,
+              },
+              {
+                content: "Rip, I hope it's fun at least",
+                me: true,
+              },
+              {
+                content: "Rip, I hope it's fun at least",
+                me: true,
+              },
+              {
+                content: "Rip, I hope it's fun at least",
+                me: true,
+              },
+              {
+                content: "Rip, I hope it's fun at least",
+                me: true,
+              },
+            ],
+          },
+          {
+            id: 2,
+            name: "Jane Doe",
+            username: "@janedoe",
+            img: "https://randomuser.me/api/portraits/women/45.jpg",
+            lastMessage:
+              "I couldn't believe it when I saw he had bought it. I really didn't expect that from him.",
+            timeLastMessage: "2w",
+            messages: [
+              {
+                content: "Hey! How have you been",
+                me: true,
+              },
+              {
+                content: "Yoooo, I've been good, you?",
+                me: false,
+              },
+            ],
+          },
+          {
+            id: 3,
+            name: "Scarlett Hienm",
+            username: "@scarlettehienm",
+            img: "https://randomuser.me/api/portraits/women/17.jpg",
+            lastMessage: "Good idea",
+            timeLastMessage: "Oct 12, 2021",
+            messages: [
+              {
+                content: "Hey! How have you been",
+                me: true,
+              },
+              {
+                content: "Yoooo, I've been good, you?",
+                me: false,
+              },
+              {
+                content: "I've been sooo busy lately",
+                me: false,
+              },
+              {
+                content: "I'm good, tired as per usual",
+                me: true,
+              },
+              {
+                content: "What's kept you busy?",
+                me: true,
+              },
+              {
+                content:
+                  "This new project I took on, man is it time consuming. I thought it was going to be a lot easier...",
+                me: false,
+              },
+              {
+                content: "Rip, I hope it's fun at least",
+                me: true,
+              },
+            ],
+          },
+        ];
+      },
+    },
+  };
+</script>

--- a/src/components/Messages/ChatMenu.vue
+++ b/src/components/Messages/ChatMenu.vue
@@ -43,7 +43,14 @@
           :to="/messages/ + user.id"
           data-cy="chat"
           class="px-0"
-          @click="conversationSelected(user.name, user.username, user.img, user.messages)"
+          @click="
+            conversationSelected(
+              user.name,
+              user.username,
+              user.img,
+              user.messages
+            )
+          "
         >
           <v-list-item :key="`user${index}`" :value="user.id">
             <v-avatar class="profile" size="40">
@@ -79,7 +86,6 @@
 
 <script>
   export default {
-    created() {},
     methods: {
       conversationSelected(name, username, img, messages) {
         this.$emit("clicked", name, username, img, messages);

--- a/src/components/Messages/ChatMenu.vue
+++ b/src/components/Messages/ChatMenu.vue
@@ -161,11 +161,11 @@
             timeLastMessage: "2w",
             messages: [
               {
-                content: "Hey! How have you been",
+                content: "Are you planning on going to the party on Friday?",
                 me: true,
               },
               {
-                content: "Yoooo, I've been good, you?",
+                content: "Not sure yet",
                 me: false,
               },
             ],
@@ -179,19 +179,19 @@
             timeLastMessage: "Oct 12, 2021",
             messages: [
               {
-                content: "Hey! How have you been",
+                content: "Happy thanksgiving! How are you?",
                 me: true,
               },
               {
-                content: "Yoooo, I've been good, you?",
+                content: "Thanks! I'm good you?",
                 me: false,
               },
               {
-                content: "I've been sooo busy lately",
+                content: "Tired of work tbh",
                 me: false,
               },
               {
-                content: "I'm good, tired as per usual",
+                content: "Oh yeah? Why's that?",
                 me: true,
               },
               {
@@ -199,12 +199,11 @@
                 me: true,
               },
               {
-                content:
-                  "This new project I took on, man is it time consuming. I thought it was going to be a lot easier...",
+                content: "The project I'm working on is taking forever",
                 me: false,
               },
               {
-                content: "Rip, I hope it's fun at least",
+                content: "Sorry to hear that",
                 me: true,
               },
             ],

--- a/src/components/Messages/MessagesComponent.vue
+++ b/src/components/Messages/MessagesComponent.vue
@@ -1,5 +1,9 @@
 <template>
-  <v-container fluid fill-height class="pa-0 d-flex justify-center align-center">
+  <v-container
+    fluid
+    fill-height
+    class="pa-0 d-flex justify-center align-center"
+  >
     <v-row class="no-gutters" style="overflow: hidden">
       <v-col
         cols="12"
@@ -10,98 +14,47 @@
         class="flex-grow-1 flex-shrink-0"
         style="border-right: 1px solid #0000001f;"
       >
-        <v-row class="py-5">
-          <v-col cols="12" align-self="center" class="py-0 pt-2">
-            <p class="primary--text font-weight-medium">Messages</p>
-            <v-divider />
-          </v-col>
-          <v-col cols="12" align-self="center" class="py-0 pt-5">
-            <v-autocomplete
-              dense
-              class="mx-4 text-body-2"
-              flat
-              hide-no-data
-              hide-details
-              label="Search for people and messages"
-              outlined
-              color="primary"
-              hide-selected
-              single
-              line
-              return-object
-              single-line
-              data-cy="search"
-            ></v-autocomplete>
-          </v-col>
-          <v-col cols="12" class="px-7">
-            <v-btn small color="primary" width="100%" data-cy="new-message">
-              <v-icon left>
-                mdi-pencil
-              </v-icon>
-              New Message
-            </v-btn>
-          </v-col>
-        </v-row>
-        <v-divider />
-        <v-responsive class="overflow-y-auto fill-height" height="65vh">
-          <v-list subheader>
-            <v-list-item-group v-model="activeChat" data-cy="chat">
-              <div v-for="(user, index) in users" :key="user.id">
-                <v-list-item :key="`user${index}`" :value="user.id">
-                  <v-avatar class="profile" size="40">
-                    <v-img :src="user.img"></v-img>
-                  </v-avatar>
-                  <v-list-item-content class="text-left pl-5">
-                    <v-col class="px-0 py-0" cols="6">
-                      <v-list-item-title
-                        v-text="user.name"
-                        class="text-wrap text-body-2"
-                      />
-                    </v-col>
-                    <v-col class="px-0 py-0" cols="6">
-                      <v-list-item-subtitle
-                        v-text="user.timeLastMessage"
-                        class="text-wrap text-right text-caption"
-                      />
-                    </v-col>
-                    <v-list-item-subtitle
-                      v-text="user.lastMessage"
-                      class="pt-2 text-caption"
-                    />
-                  </v-list-item-content>
-                </v-list-item>
-                <v-divider :key="`chatDivider${index}`" class="my-0" />
-              </div>
-            </v-list-item-group>
-          </v-list>
-        </v-responsive>
+        <ChatMenu @clicked="conversationSelected" />
       </v-col>
 
       <v-col cols="auto" class="flex-grow-1 flex-shrink-0">
-         <v-row v-if="activeChat" class="pl-3" v-on:change="$vuetify.goTo(9999)">
-              <v-col cols="1" class="pt-5">
-                <v-avatar class="profile" size="40">
-                  <v-img
-                    src="https://randomuser.me/api/portraits/men/52.jpg"
-                  ></v-img>
-                </v-avatar>
-              </v-col>
-              <v-col cols="6">
-                <v-card-title class="text-body-1">
-                  John Doe
-                </v-card-title>
-                <v-card-subtitle class="text-left text--lighten-2">
-                  @johndoe
-                </v-card-subtitle>
-              </v-col>
-            </v-row>
-            <v-divider v-if="activeChat" />
-        <v-responsive
-          v-if="activeChat"
-          class="overflow-y-hidden fill-height"
-          height="80vh"
-        >
-          <v-card flat class="d-flex flex-column fill-height" data-cy="messages-window">
+        <v-row class="pl-3" v-on:change="$vuetify.goTo(9999)">
+          <v-col cols="1" class="pt-8">
+            <v-avatar class="profile" size="40">
+              <v-img :src="avatar"></v-img>
+            </v-avatar>
+          </v-col>
+          <v-col cols="6">
+            <v-card-title class="text-body-1">
+              {{ name }}
+            </v-card-title>
+            <v-card-subtitle class="text-left text--lighten-2">
+              {{ username }}
+            </v-card-subtitle>
+          </v-col>
+        </v-row>
+        <v-divider v-if="activeChat" />
+        <v-responsive class="overflow-y-hidden fill-height" height="80vh">
+          <v-card
+            v-if="!activeChat"
+            flat
+            class="fill-height d-flex align-center justify-center"
+            data-cy="no-messages-window"
+          >
+            <v-list>
+              <h2 class="primary--text font-weight-light">Your messages</h2>
+              <v-list-item-subtitle
+                >Send private messages and attachments to a friend or
+                group</v-list-item-subtitle
+              >
+            </v-list>
+          </v-card>
+          <v-card
+            v-if="activeChat"
+            flat
+            class="d-flex flex-column fill-height"
+            data-cy="messages-window"
+          >
             <v-card-text class="flex-grow-1 overflow-y-auto">
               <div
                 v-for="msg in messages"
@@ -137,11 +90,24 @@
                 data-cy="send-message"
               >
                 <template v-slot:prepend-inner>
-                  <v-icon @click="click" class="mr-2" color="primary">insert_emoticon</v-icon>
+                  <v-icon @click="click" class="mr-2" color="primary"
+                    >insert_emoticon</v-icon
+                  >
                 </template>
                 <template v-slot:append>
-                  <v-icon class="px-2" @click="click" color="primary" data-cy="image-button">image</v-icon>
-                  <v-icon @click="messages.push(messageForm)" color="primary" data-cy="send-button">send</v-icon>
+                  <v-icon
+                    class="px-2"
+                    @click="click"
+                    color="primary"
+                    data-cy="image-button"
+                    >image</v-icon
+                  >
+                  <v-icon
+                    @click="messages.push(messageForm)"
+                    color="primary"
+                    data-cy="send-button"
+                    >send</v-icon
+                  >
                 </template>
               </v-text-field>
             </v-card-text>
@@ -153,102 +119,41 @@
 </template>
 
 <script>
+  import ChatMenu from "../Messages/ChatMenu.vue";
   export default {
     name: "MessagesComponent",
+    components: {
+      ChatMenu,
+    },
     props: {
       image: String,
     },
+    created() {
+      if (performance.getEntriesByType("navigation")[0].type == "reload") {
+        this.$router.push({ path: "/messages/0" });
+      }
+    },
     data: () => ({
-      activeChat: 1,
-      users: [
-        {
-          id: 1,
-          name: "John Doe",
-          active: false,
-          img: "https://randomuser.me/api/portraits/men/52.jpg",
-          lastMessage: "What are you up to today?",
-          timeLastMessage: "5m",
-        },
-        {
-          id: 2,
-          name: "Jane Doe",
-          active: false,
-          img: "https://randomuser.me/api/portraits/women/45.jpg",
-          lastMessage:
-            "I couldn't believe it when I saw he had bought it. I really didn't expect that from him.",
-          timeLastMessage: "2w",
-        },
-        {
-          id: 3,
-          name: "Scarlett Hienm",
-          active: false,
-          img: "https://randomuser.me/api/portraits/women/17.jpg",
-          lastMessage: "Good idea",
-          timeLastMessage: "Oct 12, 2021",
-        },
-      ],
-      messages: [
-        {
-          content: "Hey! How have you been",
-          me: true,
-        },
-        {
-          content: "Yoooo, I've been good, you?",
-          me: false,
-        },
-        {
-          content: "I've been sooo busy lately",
-          me: false,
-        },
-        {
-          content: "I'm good, tired as per usual",
-          me: true,
-        },
-        {
-          content: "What's kept you busy?",
-          me: true,
-        },
-        {
-          content: "This new project I took on, man is it time consuming. I thought it was going to be a lot easier...",
-          me: false,
-        },
-        {
-          content: "Rip, I hope it's fun at least",
-          me: true,
-        },
-        {
-          content: "Rip, I hope it's fun at least",
-          me: true,
-        },
-        {
-          content: "Rip, I hope it's fun at least",
-          me: true,
-        },
-        {
-          content: "Rip, I hope it's fun at least",
-          me: true,
-        },
-        {
-          content: "Rip, I hope it's fun at least",
-          me: true,
-        },
-        {
-          content: "Rip, I hope it's fun at least",
-          me: true,
-        },
-        {
-          content: "Rip, I hope it's fun at least",
-          me: true,
-        },
-      ],
+      activeChat: false,
+      name: "",
+      username: "",
+      avatar: "",
+      messages: [],
       messageForm: {
         content: "",
         me: true,
       },
     }),
-     methods: {
-      click () {
-        alert('You clicked the icon!')
+    methods: {
+      click() {
+        alert("You clicked the icon!");
+      },
+      conversationSelected(name, username, avatar, message) {
+        this.name = name;
+        this.username = username;
+        this.avatar = avatar;
+        this.messages = message;
+        this.activeChat = true;
       },
     },
   };

--- a/src/components/SideMenu/SideMenu.vue
+++ b/src/components/SideMenu/SideMenu.vue
@@ -18,12 +18,12 @@
           <v-container class="mb-0 pb-0 mx-0 px-0">
             <v-row no-gutters>
               <v-col>
-                <router-link 
+                <router-link
                   to="/following"
                   class="black--text font-weight-bold"
                   style="text-decoration: none; font-size: 12px"
                 >
-                  {{ numFollowing + " Following" }} 
+                  {{ numFollowing + " Following" }}
                 </router-link>
               </v-col>
               <v-col>
@@ -32,14 +32,14 @@
                   class="black--text font-weight-bold"
                   style="text-decoration: none; font-size: 12px"
                 >
-                  {{ numFollowers + " Followers" }} 
+                  {{ numFollowers + " Followers" }}
                 </router-link>
               </v-col>
             </v-row>
           </v-container>
         </v-list-item-content>
       </v-list-item>
-      
+
       <v-divider class="my-3 hidden-sm-and-down" />
 
       <v-list dense nav>
@@ -90,7 +90,7 @@
           </v-list-item>
         </v-list-item-group>
       </v-list>
-      
+
       <template v-slot:append>
         <v-container class="hidden-sm-and-down">
           <v-row no-gutters>
@@ -117,10 +117,12 @@
           </v-row>
           <v-row no-gutters>
             <v-col class="text-center text-caption mt-1  grey--text ">
-              <v-icon size="17" >
+              <v-icon size="17">
                 mdi-copyright
               </v-icon>
-              <span class="grey--text text--darken-2 font-weight-bold">TradeShare</span>
+              <span class="grey--text text--darken-2 font-weight-bold"
+                >TradeShare</span
+              >
             </v-col>
           </v-row>
         </v-container>
@@ -130,55 +132,52 @@
 </template>
 <!-- TradeZone icon could also be chart-areaspline-->
 <script>
-export default {
-  data() {
-    return {
-      selectedItem: "",
-      upperNav: [
-        {
-          title: "Trade Zone",
-          icon: "mdi-target-variant",
-          route: "/tradezone",
-        },
-        {
-          title: "Dashboard",
-          icon: "mdi-view-dashboard",
-          route: "/dashboard",
-        },
-        { title: "Messages",
-          icon: "mdi-forum",
-          route: "/messages"
-        },
-        {
-          title: "Preferences",
-          icon: "mdi-lock-open-outline ",
-          route: "/preferences",
-        },
-        {
-          title: "Connected Apps",
-          icon: "mdi-apps ",
-          route: "/connected-apps",
-        },
-      ],
-      lowerNav: [
-        {
-          title: "Support",
-          icon: "mdi-help-circle-outline",
-          route: "/support",
-        },
-      ],
-      since: "Member since 2021",
-      numFollowing: "190K",
-      numFollowers: "295K",
-    };
-  },
-  computed: {
-    mini() {
-      return this.$vuetify.breakpoint.smAndDown;
+  export default {
+    data() {
+      return {
+        selectedItem: "",
+        upperNav: [
+          {
+            title: "Trade Zone",
+            icon: "mdi-target-variant",
+            route: "/tradezone",
+          },
+          {
+            title: "Dashboard",
+            icon: "mdi-view-dashboard",
+            route: "/dashboard",
+          },
+          { title: "Messages", icon: "mdi-forum", route: "/messages/0" },
+          {
+            title: "Preferences",
+            icon: "mdi-lock-open-outline ",
+            route: "/preferences",
+          },
+          {
+            title: "Connected Apps",
+            icon: "mdi-apps ",
+            route: "/connected-apps",
+          },
+        ],
+        lowerNav: [
+          {
+            title: "Support",
+            icon: "mdi-help-circle-outline",
+            route: "/support",
+          },
+        ],
+        since: "Member since 2021",
+        numFollowing: "190K",
+        numFollowers: "295K",
+      };
     },
-    user() {
-      return JSON.parse(localStorage.getItem("user"));
+    computed: {
+      mini() {
+        return this.$vuetify.breakpoint.smAndDown;
+      },
+      user() {
+        return JSON.parse(localStorage.getItem("user"));
+      },
     },
-  },
-};
+  };
 </script>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -59,8 +59,9 @@ const routes = [
     component: Followers,
   },
   {
-    path: "/messages",
+    path: "/messages/:id",
     name: "Messages",
+    props: true,
     component: Messages,
   },
   {


### PR DESCRIPTION
Changes made:
- Messaging page url is now "messages/0"
- Each chat has it's own unique url "messages/X" where X is the id of the user
- Search bar now has a magnifying glass icon to match navbar

Acceptance Criteria (for changes made):
- [ ] Going to the messaging page should lead to the chat menu with no chat open (url: /messages/0)
- [ ] Clicking on any chat should open the chat window, displaying the user's avatar, name and username, and messages (url: /messages/X)
- [ ] Refreshing the page should close the chat (url: /messages/0)

Please note no change has been made for the sending messages feature, and does not cover the scroll-to-bottom feature (that'll be in another PR). Also, the cypress test was modified slightly to accommodate the new structure.